### PR TITLE
Auto-add newline

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,6 +9,7 @@
   "cSpell.words": ["isort", "pylint", "yapf", "pytest", "instafail", "AGRC"],
   "editor.formatOnSave": true,
   "editor.rulers": [120],
+  "files.insertFinalNewline": true,
   "coverage-gutters.showGutterCoverage": true,
   "coverage-gutters.showLineCoverage": true,
   "coverage-gutters.showRulerCoverage": false,


### PR DESCRIPTION
pylint wants newlines at the end of every file. This automatically adds them when the file is saved. 

Alternatively, we could ignore pylint message C0304.

Thoughts?