### PR TITLE
feat: add arcpy scratch envs to pylint ignore

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -3,4 +3,4 @@ load-plugins=pylint_quotes
 max-line-length=120
 disable=bad-continuation,broad-except
 ignore-patterns=test_.*?py
-generated-members=arcpy.da.SearchCursor,arcpy.da.UpdateCursor,arcpy.da.Describe
+generated-members=arcpy.da.SearchCursor,arcpy.da.UpdateCursor,arcpy.da.Describe,arcpy.env.scratchFolder,arcpy.env.scratchGDB


### PR DESCRIPTION
Adding the scratch folder, GDB, and workspace environment settings to the pylint ignore list.

I'm also getting no-member errors on things like `gis.content.get()` and `gis.users.me` (where `gis` is an instance of the `arcgis.gis.GIS` class), but I couldn't figure out how to add those to the list (tried both `arcgis.gis.GIS.content.get` and `content.git` but neither worked).