### PR TITLE
build: editable is unnecessary and installed twice

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,7 @@ language: python
 python:
   - "3.6"
 install:
-  - pip install -e .
-before_script:
-  - pip install -e ."[tests]"
+  - pip install ."[tests]"
 script:
   - pytest
 after_success:


### PR DESCRIPTION
travis does not need an editable module to run the tests and we don't need to install the package twice