### PR TITLE
Vscode tests integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ __pycache__
 .env/
 .DS_Store
 cov.xml
+.coverage

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Debug Tests",
+      "type": "python",
+      "request": "test",
+      "console": "integratedTerminal",
+      "env": {
+        "PYTEST_ADDOPTS": "--no-cov"
+      }
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,25 +1,37 @@
 {
-  "python.linting.enabled": true,
-  "python.linting.pylintEnabled": true,
-  "python.linting.flake8Enabled": false,
-  "python.linting.pycodestyleEnabled": false,
-  "python.formatting.provider": "yapf",
-  "python.formatting.yapfPath": "yapf",
-  "python.formatting.yapfArgs": ["--style", "${workspaceRoot}/setup.cfg"],
-  "cSpell.words": ["isort", "pylint", "yapf", "pytest", "instafail", "AGRC"],
-  "editor.formatOnSave": true,
-  "editor.rulers": [120],
-  "files.insertFinalNewline": true,
-  "coverage-gutters.showGutterCoverage": true,
-  "coverage-gutters.showLineCoverage": true,
-  "coverage-gutters.showRulerCoverage": false,
+  "cSpell.words": [
+    "isort",
+    "pylint",
+    "yapf",
+    "pytest",
+    "instafail",
+    "AGRC"
+  ],
   "coverage-gutters.highlightdark": "rgb(61, 153, 112, .05)",
   "coverage-gutters.noHighlightDark": "rgb(255, 65, 54, .05)",
   "coverage-gutters.partialHighlightDark": "rgb(255, 133, 27, .05)",
+  "coverage-gutters.showGutterCoverage": true,
+  "coverage-gutters.showLineCoverage": true,
+  "coverage-gutters.showRulerCoverage": false,
   "editor.codeActionsOnSave": {
     "source.organizeImports": true
   },
-  "python.testing.unittestEnabled": false,
+  "editor.formatOnSave": true,
+  "editor.rulers": [
+    120
+  ],
+  "files.insertFinalNewline": true,
+  "python.formatting.provider": "yapf",
+  "python.formatting.yapfArgs": [
+    "--style",
+    "${workspaceRoot}/setup.cfg"
+  ],
+  "python.formatting.yapfPath": "yapf",
+  "python.linting.enabled": true,
+  "python.linting.flake8Enabled": false,
+  "python.linting.pycodestyleEnabled": false,
+  "python.linting.pylintEnabled": true,
   "python.testing.nosetestsEnabled": false,
-  "python.testing.pytestEnabled": true
+  "python.testing.pytestEnabled": true,
+  "python.testing.unittestEnabled": false
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,5 +18,8 @@
   "coverage-gutters.partialHighlightDark": "rgb(255, 133, 27, .05)",
   "editor.codeActionsOnSave": {
     "source.organizeImports": true
-  }
+  },
+  "python.testing.unittestEnabled": false,
+  "python.testing.nosetestsEnabled": false,
+  "python.testing.pytestEnabled": true
 }

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ AGRC's default Python project configuration/template
    - `pip install -e ".[tests]"`
    - add any project requirements to the `setup.py:install_requires` array
 1. Run the tests
+   - VSCode -> `Python: Run All Tests` or `Python: Debug All Tests`
    - `ptw`
      - **P**y**t**est **W**atch will restart the tests every time you save a file
 1. Bring your test code coverage to 80% or above!


### PR DESCRIPTION
This adds configuration for running pytest tests in VSCode.

I wasn't able to find a way to run the tests automatically on save and [it appears that the maintainers don't plan on adding it](https://github.com/microsoft/vscode-python/issues/13779). :(

The launch configuration is there to disable code coverage when debugging tests. You can read more about that here: https://code.visualstudio.com/docs/python/testing#_pytest-configuration-settings

