### PR TITLE
add third arcpy cursor to pylint no-member ignore

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -3,4 +3,4 @@ load-plugins=pylint_quotes
 max-line-length=120
 disable=bad-continuation,broad-except
 ignore-patterns=test_.*?py
-generated-members=arcpy.da.SearchCursor,arcpy.da.UpdateCursor,arcpy.da.Describe,arcpy.env.scratchFolder,arcpy.env.scratchGDB
+generated-members=arcpy.da.SearchCursor,arcpy.da.UpdateCursor,arcpy.da.InsertCursor,arcpy.da.Describe,arcpy.env.scratchFolder,arcpy.env.scratchGDB


### PR DESCRIPTION
We're missing the third type of cursor (InsertCursor).