### PR TITLE
suggestion: Use version.py as single source of truth for version number

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,9 +9,14 @@ from os.path import basename, splitext
 
 from setuptools import find_packages, setup
 
+#: Load version from source file
+version = {}
+with open('src/projectname/version.py') as fp:
+    exec(fp.read(), version)
+
 setup(
     name='projectname',
-    version='1.0.0',
+    version=version['__version__'],
     license='MIT',
     description='Project description.',
     author='AGRC',

--- a/src/projectname/main.py
+++ b/src/projectname/main.py
@@ -5,6 +5,8 @@ a description of what this module does.
 this file is for testing linting...
 """
 
+import version
+
 TEST = 'test'
 
 
@@ -17,6 +19,8 @@ def hello():
         'this is a really, really, really, really, really, really, really, really, really, really, really, really,'
         'really long line'
     )
+
+    print(f'Version: {version.__version__}')
 
     return 'hi'
 

--- a/src/projectname/version.py
+++ b/src/projectname/version.py
@@ -1,0 +1,3 @@
+"""A single source of truth for the version in a programatically-accessible variable."""
+
+__version__ = '1.0.0'

--- a/src/projectname/version.py
+++ b/src/projectname/version.py
@@ -1,3 +1,6 @@
-"""A single source of truth for the version in a programatically-accessible variable."""
+"""A single source of truth for the version in a programatically-accessible variable.
+
+This must only include a single line: __version__ = 'x.y.z'
+"""
 
 __version__ = '1.0.0'


### PR DESCRIPTION
Current practice (forklift, supervisor) is to use `pkg_resources.require(project_name)` to get the version number defined during the pip install. This has two deficiencies:

1.  `project_name` needs to be set to perfectly match your package name. It's another potential source of DRY errors.
2. This requires the package to be installed by pip. Scripts that aren't pip installed (mainly Google Cloud Functions, but also quick-n-dirty local scripts) will fail here.

Instead, using method 3 from https://packaging.python.org/en/latest/guides/single-sourcing-package-version/, I propose we use a `version.py` within the package's `src/package` directory. This gives any code direct access to version.__version__ and setup.py can still read it in. There is an `exec` call, but it is limited to setup.py and shouldn't need to be changed (except for updating the projectname).

This method seems to provide the simplest programmatic access to the version for non-pip installable scripts.

Thoughts?