### PR TITLE
chore: mock_arcpy, CI improvements, readme

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,9 @@
 version: 2
 updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
   - package-ecosystem: pip
     directory: /
     schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,12 +9,18 @@ jobs:
 
     steps:
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
-        python-version: 3.8
+        python-version: 3.9
+
+    #: Uncomment this if you're using arcgis >= 2.0.0
+    # - name: Install libkrb5 for Kerberos on Linux
+    #   run: |
+    #     sudo apt install -y libkrb5-dev
+    #     pip install requests-kerberos
 
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Install module
       run: pip install .[tests]
@@ -23,7 +29,7 @@ jobs:
       run: pytest
 
     - name: Report coverage to Codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v3
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: ./cov.xml

--- a/README.md
+++ b/README.md
@@ -12,17 +12,23 @@ UGRC's default Python project configuration/template
      - `python -m venv .env`
      - activate the environment `source .env/bin/activate`
    - With conda
-     - `conda create --name PROJECT_NAME python=3.7`
+     - `conda create --name PROJECT_NAME python=3.9`
 1. Rename `src/projectname` folder to your desired project name
 1. Edit the `setup.py:name, url, project_urls, keywords, and entry_points` to reflect your new project name
 1. Edit the `test_projectname.py` to match your project name.
    - You will have one `test_filename.py` file for each file in your `src` directory and you will write tests for the specific file in the `test_filename.py` file
-1. Navigate to [codecov.io](https://codecov.io/gh/agrc/python) and create a `CODECOV_TOKEN` [project secret](https://github.com/agrc/python/settings/secrets)
+   - If you are using arcpy, you should mock out the arcpy module in any test that directly imports arcpy or tests any of your code that imports arcpy by adding `import mock_arcpy` to the imports in your test file. This replaces all of arcpy with a Mock object; you can then create custom `return_value`s and `side_effects` for whatever functions you need, and the tests will run appropriately in GitHub Actions (which doesn't have arcpy installed).
+1. Set up Codecov to create coverage reports from GitHub Actions:
+   - Navigate to [codecov.io](https://codecov.io/gh/agrc/python), logging in with your GitHub account if necessary.
+   - Select your new repo and and copy the Upload Token.
+   - Create a new repository secret (github repository Settings -> Secrets -> Actions secrets -> New repository secret) named `CODECOV_TOKEN` and paste the Upload Token as the Value
 1. Install an editable package for development
    - `pip install -e ".[tests]"`
-   - add any project requirements to the `setup.py:install_requires` array
+   - Add any project requirements to the `setup.py:install_requires` array
+   - If you specify `arcgis` version 2.0.0 or greater, uncomment the section in `.github/workflows/ci.yml` so that GitHub Actions installs the necessary dependencies.
 1. Run the tests
    - VSCode -> `Python: Run All Tests` or `Python: Debug All Tests`
    - `ptw`
      - **P**y**t**est **W**atch will restart the tests every time you save a file
 1. Bring your test code coverage to 80% or above!
+1. Replace `python` in the badge links at the top of this page with your new repository name.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ UGRC's default Python project configuration/template
 1. Edit the `setup.py:name, url, project_urls, keywords, and entry_points` to reflect your new project name
 1. Edit the `test_projectname.py` to match your project name.
    - You will have one `test_filename.py` file for each file in your `src` directory and you will write tests for the specific file in the `test_filename.py` file
-   - If you are using arcpy, you should mock out the arcpy module in any test that directly imports arcpy or tests any of your code that imports arcpy by adding `import mock_arcpy` to the imports in your test file. This replaces all of arcpy with a Mock object; you can then create custom `return_value`s and `side_effects` for whatever functions you need, and the tests will run appropriately in GitHub Actions (which doesn't have arcpy installed).
+   - If you are using arcpy, you should mock out the arcpy module in any test that directly imports arcpy or tests any of your code that imports arcpy. Add `import mock_arcpy` to the imports in your test file before importing arcpy or any of your modules that you're testing. This effectively replaces all of arcpy in the test environment with a Mock object; you can then create custom `return_value`s and `side_effects` for whatever functions you need, and the tests will run appropriately in GitHub Actions (which doesn't have arcpy installed).
 1. Set up Codecov to create coverage reports from GitHub Actions:
    - Navigate to [codecov.io](https://codecov.io/gh/agrc/python), logging in with your GitHub account if necessary.
    - Select your new repo and and copy the Upload Token.

--- a/tests/mock_arcpy.py
+++ b/tests/mock_arcpy.py
@@ -6,6 +6,6 @@ modules that import arcpy in turn.
 import sys
 from unittest.mock import Mock
 
-module_name = 'arcpy'
-arcpy = Mock(name=module_name)
-sys.modules[module_name] = arcpy
+MODULE_NAME = 'arcpy'
+arcpy = Mock(name=MODULE_NAME)
+sys.modules[MODULE_NAME] = arcpy

--- a/tests/mock_arcpy.py
+++ b/tests/mock_arcpy.py
@@ -1,0 +1,11 @@
+"""This allows you to mock out the entire arcpy package so that you can test packages that use arcpy in github's CI
+environment. You just need to 'import mock_arcpy' prior to importing arcpy directly or importing any other packages/
+modules that import arcpy in turn.
+"""
+
+import sys
+from unittest.mock import Mock
+
+module_name = 'arcpy'
+arcpy = Mock(name=module_name)
+sys.modules[module_name] = arcpy


### PR DESCRIPTION
- Create `mock_arcpy.py` to assist in testing scripts that require arcpy
- Update python version now that Pro uses 3.9
- Add section to testing workflow to install `arcgis`>=2.0.0 dependencies
- Update readme with these additions and other, more detailed instructions for things that I always have to re-figure out every time I use this template.