### PR TITLE
Update packaging and distribution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,38 @@
+name: Release Events
+on:
+  release:
+    types: [published]
+
+env:
+  GH_TOKEN: ${{ github.token }}
+
+jobs:
+  publish:
+    name: Build and Publish
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: ⬇️ Set up code
+        uses: actions/checkout@v3
+
+      - name: 🐍 Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: 3.9
+
+      - name: 👊 Bump version
+        run: |
+          TAG=$(gh release view --json tagName --jq ".tagName")
+          sed -i "s/__version__ = .*$/__version__ = '$TAG'/" src/projectname/version.py
+
+      - name: Install wheel
+        run: pip install wheel
+
+      - name: 📦 Build package
+        run: python setup.py sdist bdist_wheel
+
+      - name: 🚀 Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -32,3 +32,22 @@ UGRC's default Python project configuration/template
      - **P**y**t**est **W**atch will restart the tests every time you save a file
 1. Bring your test code coverage to 80% or above!
 1. Replace `python` in the badge links at the top of this page with your new repository name.
+
+### Publishing to PyPI with GitHub Actions
+
+The `release.yml` GitHub action will publish a [GitHub release](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository) to PyPI. Publishing from GitHub ensures that files in your `.gitignore` file (such as secrets files and other credentials) won't accidentally be uploaded to PyPI because they won't (or at least shouldn't) be in your GitHub repository.
+
+1. Update `src/projectname/version.py` in the sed command in `release.yml` to point to the proper version file in your project structure.
+1. Create a [PyPI API token](https://pypi.org/help/#apitoken) for your project.
+   - Limit its scope to just this one project—you'll create a new token for every individual project
+1. Create a new repository secret (github repository Settings -> Secrets -> Actions secrets -> New repository secret) named `PYPI_API_TOKEN` and paste the token as the value.
+
+This action will be triggered whenever you cut a new release on GitHub:
+
+1. Draft a new release in your GitHub repo.
+1. Choose the appropriate [tag](https://docs.github.com/en/desktop/contributing-and-collaborating-using-github-desktop/managing-commits/managing-tags) to specify which version/code state should be released
+   a. If you've been adding tags via the desktop client as linked above, or through VSCode, select the appropriate tag.
+   a. If you haven't already added a tag, type in a new version and select "Create a new tag." Select the proper target branch (main, dev, etc) to apply the tag to.
+   a. Version numbers should use PEP 440-compliant [semantic versioning](https://semver.org/) in the form `x.y.z`, where major version `x` increases whenever you make a breaking change, minor version `y` increases whenever you make a substantial but non-breaking change (adding new features, etc), and patch `z` changes whenever you make a small, non-breaking quick fix or change.
+1. Make sure "Set as a pre-release" is left unchecked. Pre-releases will fail to publish.
+1. Publish the release. This will kick off the publish action, and if all goes well your package will be available on PyPI.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ UGRC's default Python project configuration/template
 
 The `release.yml` GitHub action will publish a [GitHub release](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository) to PyPI. Publishing from GitHub ensures that files in your `.gitignore` file (such as secrets files and other credentials) won't accidentally be uploaded to PyPI because they won't (or at least shouldn't) be in your GitHub repository.
 
+**NOTE:** Make sure your README.md is fit for public consumption. It will be uploaded to PyPI and displayed as your project's main page for the version you upload.
+
 1. Update `src/projectname/version.py` in the sed command in `release.yml` to point to the proper version file in your project structure.
 1. Create a [PyPI API token](https://pypi.org/help/#apitoken) for your project.
    - Limit its scope to just this one project—you'll create a new token for every individual project

--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,7 @@
 setup.py
 A module that installs projectname as a module
 """
-from glob import glob
-from os.path import basename, splitext
+from pathlib import Path
 
 from setuptools import find_packages, setup
 
@@ -17,20 +16,21 @@ with open('src/projectname/version.py') as fp:
 setup(
     name='projectname',
     version=version['__version__'],
-    license='MIT',
     description='Project description.',
+    long_description=(Path(__file__).parent / 'README.md').read_text(),
+    long_description_content_type='text/markdown',
     author='UGRC',
     author_email='ugrc@utah.gov',
     url='https://github.com/agrc/python',
     packages=find_packages('src'),
     package_dir={'': 'src'},
-    py_modules=[splitext(basename(path))[0] for path in glob('src/*.py')],
     include_package_data=True,
     zip_safe=True,
     classifiers=[
         # complete classifier list: http://pypi.python.org/pypi?%3Aaction=list_classifiers
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
+        'License :: OSI Approved :: MIT License',
         'Topic :: Utilities',
     ],
     project_urls={
@@ -43,14 +43,14 @@ setup(
     extras_require={
         'tests': [
             'pylint-quotes~=0.2',
-            'pylint~=2.11',
+            'pylint~=2.15',
             'pytest-cov~=4.0',
             'pytest-instafail~=0.4',
             'pytest-isort>=2,<4',
             'pytest-pylint~=0.18',
             'pytest-watch~=4.2',
             'pytest>=6,<8',
-            'yapf~=0.31',
+            'yapf~=0.32',
         ],
         'dev': [
             'pylint~=2.15',
@@ -61,6 +61,6 @@ setup(
         'pytest-runner',
     ],
     entry_points={'console_scripts': [
-        'projectname = projectname.main:main',
+        'command_name = projectname.module:function',
     ]},
 )

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     long_description=(Path(__file__).parent / 'README.md').read_text(),
     long_description_content_type='text/markdown',
     author='UGRC',
-    author_email='ugrc@utah.gov',
+    author_email='ugrc-developers@utah.gov',
     url='https://github.com/agrc/python',
     packages=find_packages('src'),
     package_dir={'': 'src'},


### PR DESCRIPTION
I've updated the template to reflect our recent python conversations:

- The `release.yml` action is included, along with instructions in the readme.
- `README.md` is included as the `long_description` key in `setup.py` as [recommended](https://packaging.python.org/en/latest/guides/making-a-pypi-friendly-readme/). This will become the content of the main page for the release on PyPI.
- The `license` keyword has been dropped in favor of adding a new license `classifier`.
- The `py_modules` keyword has been dropped. 
  - Everything I could find seemed to indicate you use `packages` & `package_dir` or `py_modules` (whether you're doing a whole package or just a single module, respectively), but not both. However, I couldn't find an explicit statement on this, so I'm not sure if there's a reason we do both.
- The boilerplate `entry_point` has been updated for clarity.